### PR TITLE
feat: Take into account flag about test overwriting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,6 @@ module.exports = (hermione, opts) => {
     hermione.on(hermione.events.AFTER_TESTS_READ, collection => {
         collection.eachTest(test => {
             const {browserId} = test;
-            const browserConfig = hermione.config.forBrowser(browserId);
-            const configVersion = browserConfig.desiredCapabilities.version;
             const versions = _.get(config.browsers, browserId, {});
             const pluginBrowserVersion = _.findKey(versions, (predicate, ver) => predicate(test, ver, opts.store));
 
@@ -28,9 +26,7 @@ module.exports = (hermione, opts) => {
                 return;
             }
 
-            // Do not override a version if it was assigned through hermione-helper "browser().version()"
-            // and as result not equals to the default version from the config file
-            if (test.browserVersion && test.browserVersion !== configVersion) {
+            if (test.hasBrowserVersionOverwritten) {
                 return;
             }
 

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -55,10 +55,10 @@ describe('plugin', () => {
         assert.include(test2, {browserVersion: '1.2'});
     });
 
-    it('should NOT set browser version if test has different version from config', () => {
+    it('should NOT set browser version if it has not overwritten from native helper', () => {
         const config = mkConfigStub({browsers: ['bro'], version: '1.0'});
         const hermione = mkHermione({config});
-        const test = {browserId: 'bro', browserVersion: '1.1'};
+        const test = {browserId: 'bro', browserVersion: '1.1', hasBrowserVersionOverwritten: true};
 
         plugin(hermione, {
             browsers: {


### PR DESCRIPTION
Do not overwrite a browser version if it has overwritten from the native hermione-helper.